### PR TITLE
Make compatible with hipSYCL

### DIFF
--- a/concurency/sycl_con.cpp
+++ b/concurency/sycl_con.cpp
@@ -92,7 +92,8 @@ std::pair<long, std::vector<long>> bench(std::string mode, std::vector<std::stri
       if (commands[i] == "C") {
         T *ptr = buffers[i][0];
         const auto kernel_tripcount = commands_parameters["tripcount_C"];
-        Q.parallel_for(N, [ptr, kernel_tripcount](sycl::item<1> j) { ptr[j] = busy_wait(kernel_tripcount, (T)j); });
+        std::size_t kernel_range = static_cast<std::size_t>(N);
+        Q.parallel_for(sycl::range{kernel_range}, [ptr, kernel_tripcount](sycl::id<1> j) { ptr[j] = busy_wait(kernel_tripcount, (T)j); });
       } else {
         //Copy is src -> dest
         Q.copy(buffers[i][0], buffers[i][1], N);


### PR DESCRIPTION
Fix two minor issues on hipSYCL:
* hipSYCL does not yet support implicit conversion from `item<1>` to `std::size_t`. This is an oversight - it's currently only implemented for `id<1>`.
* there seems to be a different behavior between DPC++ and hipSYCL regarding implicit conversion from `long` to `sycl::range<1>`; in hipSYCL it seems to not work because of the difference in signedness, and the implicit conversion does particularly not work within the heavily templated `parallel_for` call. The implicit conversion behavior  can change depending on whether templates or function overloads are used; my guess is that hipSYCL and DPC++ do things differently here. I'd have to check, but this might be a gap in the specification.